### PR TITLE
fix(sb-grid): default sorting order

### DIFF
--- a/packages/ui/src/runtime/components/molecules/SbGrid.vue
+++ b/packages/ui/src/runtime/components/molecules/SbGrid.vue
@@ -48,7 +48,7 @@
 <script>
 import get from 'lodash.get'
 const POST_TYPE = 'projekte'
-const SORT_BY = 'created_at:desc'
+const SORT_BY = ''
 const RESOLVE_RELATIONS = ''
 const PER_PAGE = 12
 const RESOLVE_LINKS = ''


### PR DESCRIPTION
## Types of changes

- [x] fix SbGrid default sorting order

## Description

This makes it possible to use the default sorting order of Storyblok (exact same order like in the Storyblok app).
